### PR TITLE
entrypoint finding first .meteor dir

### DIFF
--- a/scripts/docker-entrypoint
+++ b/scripts/docker-entrypoint
@@ -31,7 +31,7 @@ fi
 
 # Run in development mode
 cd /app
-METEOR_DIR=$(find ./ -type d -name .meteor -printf '%P\n')
+METEOR_DIR=$(find ./ -type d -name .meteor -printf '%P\n' | head -1)
 if [ -n "${METEOR_DIR}" ]
 then
     echo "Running Meteor application in development mode..."


### PR DESCRIPTION
Had a situation where it was finding a `.meteor` dir that showed up in one of my packages, populating `METEOR_DIR` with `.meteor` and `.meteor/local/mirrors/jasmine-server-integration/.meteor`. Consequently the app tries to start from the wrong location and fails. Now only using first match.